### PR TITLE
Potential fix for code scanning alert no. 15: Uncontrolled data used in path expression

### DIFF
--- a/PROJETO_DE_EXTENSAO_I.py
+++ b/PROJETO_DE_EXTENSAO_I.py
@@ -18,6 +18,9 @@ from pypdf import PdfReader
 
 app = Flask(__name__)
 
+# Defina aqui o diretório raiz confiável para processamento
+BASE_ROOT_DIR = "/trusted/base/dir"  # Altere conforme necessário para o ambiente de produção
+
 def validar_caminho_seguro(caminho):
     """
     Valida e sanitiza um caminho de arquivo para prevenir path injection.
@@ -63,7 +66,15 @@ def validar_caminho_seguro(caminho):
                 return False, "Caminho não existe"
         except (OSError, PermissionError):
             return False, "Acesso negado ao caminho"
-            
+        
+        # NOVO: Verificar se o caminho está dentro da BASE_ROOT_DIR confiável
+        base_root = Path(BASE_ROOT_DIR).resolve()
+        try:
+            # O método .relative_to() lança ValueError se caminho_path não estiver dentro de base_root
+            caminho_path.relative_to(base_root)
+        except ValueError:
+            return False, f"Caminho fora do diretório permitido ({BASE_ROOT_DIR})"
+        
         # Verificar se é um diretório
         try:
             if not caminho_path.is_dir():


### PR DESCRIPTION
Potential fix for [https://github.com/Delean-Mafra/pex/security/code-scanning/15](https://github.com/Delean-Mafra/pex/security/code-scanning/15)

To address the uncontrolled path usage, you should validate that any user-supplied directory path is **strictly contained within a configured safe base folder**. This is best accomplished by:
- Defining a constant root folder (e.g., `/server/static/images/` or a similar trusted path).
- When a path is received from the user, normalize and resolve the candidate path, and then verify that it is a subdirectory (not just a prefix match) of the root folder using absolute paths (to avoid path traversal).
- Only allow operations on paths satisfying this constraint; reject others.

To implement in your code:
1. Set a top-level trusted directory (e.g., at the top of the script or inside `validar_caminho_seguro`), e.g., `ROOT_DIR = "/trusted/base/dir"` (replace with a suitable path).
2. In `validar_caminho_seguro`, resolve both the base and candidate path, and ensure the candidate path is strictly within the base.
3. Update the function to use this additional containment check before allowing any file operations.

No existing functionality will change except for tightening security controls; all file-processing will be limited to the trusted base directory and its subdirectories.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
