### PR TITLE
Fix f-string quoting SyntaxError in PyInstaller command

### DIFF
--- a/version_compilador.py
+++ b/version_compilador.py
@@ -92,8 +92,8 @@ pyinstaller_cmd = [
     f'--name={exe_name}',
     f'--version-file={correct_version_file_path}',
     f'--icon={icon_path}',
-    f'--distpath={BASE_DIR / 'dist'}',
-    f'--workpath={BASE_DIR / 'build'}',
+    f"--distpath={BASE_DIR / 'dist'}",
+    f"--workpath={BASE_DIR / 'build'}",
     f'--specpath={BASE_DIR}',
     # Módulos necessários para o app Flask de exclusão (reduzido para acelerar build)
     '--hidden-import=flask',


### PR DESCRIPTION
### Motivation
- A malformed pair of single-quoted f-strings in `version_compilador.py` caused a `SyntaxError` at parse time, preventing the build script from being imported or executed.

### Description
- Replaced two malformed single-quoted f-strings with double-quoted f-strings for the `--distpath` and `--workpath` entries in the `pyinstaller_cmd` list inside `version_compilador.py` so the embedded single quotes parse correctly.

### Testing
- Ran `python -m py_compile *.py` to ensure all Python files compile and it succeeded.
- Ran `pytest -q` and the test suite passed (`2 passed`).
- Executed the comprehensive validation script `python comprehensive_test.py` and it reported all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47d0f938c8329a01534fffe557733)