### PR TITLE
fix: atualizar pypdf para >=6.8.0 para resolver alertas do Dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ MarkupSafe>=3.0.2
 Pillow>=11.3.0
 
 # PDFs (sucessor oficial do PyPDF2)
-pypdf>=5.6.1
+# >=6.8.0 corrige CVEs reportadas pelo Dependabot (#24 e #25).
+pypdf>=6.8.0


### PR DESCRIPTION
### Motivation
- Resolver dois alertas do Dependabot que reportaram vulnerabilidades em `pypdf` (ineficiência em `ASCIIHexDecode` e manipulação de valores `/Length`) exigindo a versão mínima corrigida.

### Description
- Atualizei `requirements.txt` para exigir `pypdf>=6.8.0` e adicionei um comentário apontando que essa versão corrige os CVEs reportados (#24 e #25).

### Testing
- Executado `python -m pip install -r requirements.txt` e `python comprehensive_test.py`, ambos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e4698ac48329bf2ddf0058ce49ab)